### PR TITLE
Update Homebrew install scripts for macOS and Debian

### DIFF
--- a/scripts/setup/darwin.sh
+++ b/scripts/setup/darwin.sh
@@ -125,15 +125,18 @@ gem_install_or_update() {
 
 if ! command -v brew >/dev/null; then
   fancy_echo "Installing Homebrew ..."
-    curl -fsS \
-      'https://raw.githubusercontent.com/Homebrew/install/master/install' | ruby
+  /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 
-    append_to_zshrc '# recommended by brew doctor'
+  append_to_zshrc '# recommended by brew doctor'
 
-    # shellcheck disable=SC2016
-    append_to_zshrc 'export PATH="/usr/local/bin:$PATH"' 1
+  BREW_PREFIX="/usr/local"
+  if [[ -d "/opt/homebrew" ]]; then
+    BREW_PREFIX="/opt/homebrew"
+  fi
 
-    export PATH="/usr/local/bin:$PATH"
+  # shellcheck disable=SC2016
+  append_to_zshrc "eval \"\$(${BREW_PREFIX}/bin/brew shellenv)\"" 1
+  eval "$(${BREW_PREFIX}/bin/brew shellenv)"
 else
   fancy_echo "Homebrew already installed. Skipping ..."
 fi

--- a/scripts/setup/debian.sh
+++ b/scripts/setup/debian.sh
@@ -23,8 +23,8 @@ sudo apt-get update
 sudo apt-get -y install curl libcurl4 libcurl4-openssl-dev
 sudo apt-get -y install build-essential file
 sudo apt-get install git git-gui gitk
-sh -c "$(curl -fsSL https://raw.githubusercontent.com/Linuxbrew/install/master/install.sh)"
-eval $(/home/linuxbrew/.linuxbrew/bin/brew shellenv)
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
 brew install gcc
 brew bundle install --file=Brewfile.debian
 


### PR DESCRIPTION
## Summary
- use official Homebrew install script on macOS
- ensure correct brew path setup for Intel and Apple Silicon
- switch Debian install to current Homebrew installer

## Testing
- `bash -n scripts/setup/darwin.sh scripts/setup/debian.sh`
- `apt-get update` *(fails: repository is not signed)*
- `apt-get install -y shellcheck` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_b_68a4bb88ac64832b9464c7b592931596