### PR TITLE
Add Neovim shim to load existing Vim configuration

### DIFF
--- a/.config/nvim/init.lua
+++ b/.config/nvim/init.lua
@@ -1,0 +1,1 @@
+vim.cmd('source ' .. vim.fn.expand('~/.config/nvim/init.vim'))

--- a/.config/nvim/init.vim
+++ b/.config/nvim/init.vim
@@ -1,0 +1,3 @@
+set runtimepath^=~/.vim runtimepath+=~/.vim/after
+let &packpath = &runtimepath
+source ~/.vimrc

--- a/scripts/makesymlinks.sh
+++ b/scripts/makesymlinks.sh
@@ -129,6 +129,9 @@ symlink_and_save_original $dotfiles/erlang/erlang \
 # Copy pgcli config. pgcli doesn't seem to support soft links
 cp $dotfiles/.config/pgcli/config $HOME/.config/pgcli/config
 
+# Symlink Neovim config directory
+symlink_and_save_original $dotfiles/.config/nvim $HOME/.config/nvim $olddir
+
 # Symlink all the scripts in scripts/tools to the bin directory
 tool_scripts=$(find $dotfiles/scripts/tools -type f \( -perm -u=x \) -print)
 IFS=$'\n'


### PR DESCRIPTION
## Summary
- Add `.config/nvim/init.vim` to source existing `.vimrc` and set runtime/pack paths
- Add `.config/nvim/init.lua` shim to load `init.vim` via Lua for plugin compatibility
- Link `nvim` config directory into `~/.config` in `scripts/makesymlinks.sh`

## Testing
- `bash -n scripts/makesymlinks.sh`
- `apt-get update >/tmp/apt-update.log && tail -n 20 /tmp/apt-update.log` *(fails: repository not signed)*
- `nvim -u .config/nvim/init.lua +q` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a90c107454832baa9936f60024918b